### PR TITLE
Change land unit sector one modifier 76 from cyber to ranger

### DIFF
--- a/tsv-tables/2525d/Land unit sector 1.tsv
+++ b/tsv-tables/2525d/Land unit sector 1.tsv
@@ -75,7 +75,7 @@ Amphibious Warfare Ship	Capability	72
 Load Handling System	Capability	73	
 Palletized Load System	Capability	74	
 Medevac	Capability	75	
-Cyberspace	Capability	76	
+Ranger	Capability	76	
 Support	Capability	77	
 Aviation	Capability	78	
 Route, Reconnaissance, and Clearance	Capability	79	


### PR DESCRIPTION
According to the 2525D standard document code 76 should be Ranger, not Cyber.