### PR TITLE
SIGINT/MOOTW: fixed function ids.

### DIFF
--- a/tsv-tables/2525b-change2/mootw.tsv
+++ b/tsv-tables/2525b-change2/mootw.tsv
@@ -1,5 +1,5 @@
 hierarchy	codingscheme	affiliation	battledimension	status	functionid	name	remarks
-MOOTW	O	*	-	*	-------	MILITARY OPERATIONS OTHER THAN WAR (MOOTW)	
+MOOTW	O	*	-	*	------	MILITARY OPERATIONS OTHER THAN WAR (MOOTW)	
 MOOTW.VIOATY	O	*	V	*	------	VIOLENT ACTIVITIES (DEATH CAUSING)	
 MOOTW.VIOATY.ASN	O	*	V	*	A-----	ARSON/FIRE	
 MOOTW.VIOATY.KILL	O	*	V	*	M-----	KILLING (GENERAL)	

--- a/tsv-tables/2525b-change2/signals-intelligence.tsv
+++ b/tsv-tables/2525b-change2/signals-intelligence.tsv
@@ -1,5 +1,5 @@
 hierarchy	codingscheme	affiliation	battledimension	status	functionid	name	remarks
-SIGINT	I	-	-	*	-------	SIGNALS INTELLIGENCE	
+SIGINT	I	-	-	*	------	SIGNALS INTELLIGENCE	
 SIGINT.SPC	I	*	P	*	------	SPACE TRACK	
 SIGINT.SPC.SIGINC	I	*	P	*	S-----	SIGNAL INTERCEPT	
 SIGINT.SPC.SIGINC.COMM	I	*	P	*	SC----	COMMUNICATIONS	


### PR DESCRIPTION
2525B: Fixes two invalid (too long) function ids in SIGINT and MOOTW.